### PR TITLE
Partially revert "remvoe dead code"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,16 @@ extern "C" fn real_main() -> ! {
     } else {
         log::info!("Neither LD_LIBRARY_PATH or NIX_LD_LIBRARY_PATH exist - Setting default");
 
+        args
+            .add_env(
+                "LD_LIBRARY_PATH",
+                DEFAULT_NIX_LD_LIBRARY_PATH.len(),
+                |buf| {
+                    buf.copy_from_slice(DEFAULT_NIX_LD_LIBRARY_PATH);
+                },
+            )
+            .unwrap();
+
         // If the entry trampoline is available on the platform, LD_LIBRARY_PATH
         // will be replaced with an empty LD_LIBRARY_PATH when ld.so launches
         // the actual program.


### PR DESCRIPTION
This reverts commit 07e746add66fdcecd92339d8a049ce5d912637ee.

This code is not in fact dead, the side effect is what's important. Remove the unused variable, but keep the side effect.