### PR TITLE
Add default NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,5 +99,6 @@
     }
     // {
       nixosModules.nix-ld = import ./modules/nix-ld.nix;
+      nixosModules.default = self.outputs.nixosModules.nix-ld;
     };
 }


### PR DESCRIPTION
Add a default module so that users can access nix-ld via `nix-ld.nixosModules.default`.